### PR TITLE
support Oracle client

### DIFF
--- a/manifests/datasource.pp
+++ b/manifests/datasource.pp
@@ -31,8 +31,9 @@ define odbc::datasource (
   "set ${name}/")
 
   augeas { "odbc datasource ${name}":
-    lens    => 'Odbc.lns',
-    incl    => '/etc/odbc.ini',
-    changes => $augeas_changes
+    lens      => 'Odbc.lns',
+    incl      => '/etc/odbc.ini',
+    changes   => $augeas_changes,
+    show_diff => false, # This contains plaintext passwords
   }
 }

--- a/manifests/driver.pp
+++ b/manifests/driver.pp
@@ -1,6 +1,7 @@
 define odbc::driver (
   $package_name      = undef,
   $package_ensure    = "present",
+  $manage_package    = true,
   $override_settings = false,
   $description       = undef,
   $driver            = undef,
@@ -17,8 +18,10 @@ define odbc::driver (
     fail("You must define driver or driver64")
   }
 
-  package { $package_name:
-    ensure => $package_ensure
+  if $manage_package {
+    package { $package_name:
+      ensure => $package_ensure
+    }
   }
   
   $augeas_changes = prefix(


### PR DESCRIPTION
Hello,

I had to modify puppet-odbc a bit to make it work with the Oracle 12c client (see the commits). Hopefully this shouldn't have any unexpected effect on other usages.

Thomas